### PR TITLE
Relative image URLs

### DIFF
--- a/src/foundryvtt-gmScreen.scss
+++ b/src/foundryvtt-gmScreen.scss
@@ -102,7 +102,7 @@ $transition-timing: 400ms;
     }
 
     .active {
-      background: url(/ui/parchment.jpg) repeat;
+      background: url(../../ui/parchment.jpg) repeat;
       text-shadow: none;
     }
 
@@ -118,7 +118,7 @@ $transition-timing: 400ms;
       }
 
       button {
-        background: url(/ui/parchment.jpg) repeat;
+        background: url(../../ui/parchment.jpg) repeat;
       }
     }
 


### PR DESCRIPTION
`foundryvtt-gmScreen.css` references several images from the Foundry VTT core. These break, however, if FVTT is served from somewhere other than the root directory (using `routePrefix` in `options.json`), leading to 404 errors in the console and very ugly buttons.

Making the URLs relative to the CSS file's location should fix this to work regardless of any route prefix.

