### PR TITLE
Revised Width/Height Step Increments from 5 to 1

### DIFF
--- a/src/module/classes/GmScreenSettings.ts
+++ b/src/module/classes/GmScreenSettings.ts
@@ -90,7 +90,7 @@ export class GmScreenSettings extends FormApplication {
       default: 100,
       type: Number,
       scope: 'client',
-      range: { min: 25, max: 100, step: 5 },
+      range: { min: 25, max: 100, step: 1 },
       config: true,
       hint: `${MODULE_ABBREV}.settings.${MySettings.drawerWidth}.Hint`,
     });
@@ -100,7 +100,7 @@ export class GmScreenSettings extends FormApplication {
       default: 60,
       type: Number,
       scope: 'client',
-      range: { min: 10, max: 90, step: 5 },
+      range: { min: 10, max: 90, step: 1 },
       config: true,
       hint: `${MODULE_ABBREV}.settings.${MySettings.drawerHeight}.Hint`,
     });


### PR DESCRIPTION
Very minor change to replace arbitrary width/height step increment to 1% from 5%. No real reason to limit this and by allowing smaller increments it helps with the blurry text mentioned in issue #106 (an, as you mentioned, by others as well)