### PR TITLE
Bugfix for #154:  content misaligned

### DIFF
--- a/src/styles/foundryvtt-gmScreen.scss
+++ b/src/styles/foundryvtt-gmScreen.scss
@@ -262,6 +262,16 @@ $transition-timing: 400ms;
       }
     }
 
+    // fix ultra large header elements
+    > header {
+      flex: 0;
+    }
+
+    .journal-page-content {
+      width: auto !important;
+      height: auto !important;
+    }
+
     .compact-journal-entry {
       min-height: 100%; // needed for dnd5e
 

--- a/src/styles/foundryvtt-gmScreen.scss
+++ b/src/styles/foundryvtt-gmScreen.scss
@@ -267,6 +267,8 @@ $transition-timing: 400ms;
       flex: 0;
     }
 
+    // fix width and height overrides by foundry that are added to the page content element
+    // via styles attribute.
     .journal-page-content {
       width: auto !important;
       height: auto !important;


### PR DESCRIPTION
Fixes both too large header elements in journal pages and page width overrides done by foundry.