### PR TITLE
Fixed deprecated "dependencies" to "relationships"."requires"

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -23,7 +23,11 @@
   "esmodules": ["module/foundryvtt-gmScreen.js"],
   "styles": ["styles/foundryvtt-gmScreen.css"],
   "packs": [],
-  "dependencies": [],
+  "relationships": [
+    {
+        "requires": ""
+    }
+  ],
   "languages": [
     {
       "lang": "de",


### PR DESCRIPTION
The "dependencies" object in json is deprecated, changed to the current "relationships" with "requires" format.  Minor, but cleans up the warning message.